### PR TITLE
transport: Replace SOCK_SEQPACKET with SOCK_STREAM

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -249,6 +249,8 @@ pub const Server = struct {
                                 // XXX: This error is caught inside Commands, probably a bug that
                                 // compiler complains about it not being caught here.
                                 error.InitParamsMustHaveEitherPathOrContent,
+                                // XXX: This error is caught inside Transport.
+                                error.EndOfStream,
                                 => unreachable,
                                 // For these errors the client is probably wrong and we can send
                                 // an error message explaining why.
@@ -276,6 +278,7 @@ pub const Server = struct {
                                 error.IsDir,
                                 error.FileTooBig,
                                 error.UninitializedClient,
+                                error.StreamTooLong,
                                 => |e| {
                                     client.send(rpc.errorResponse(client.state.id, e)) catch {
                                         std.debug.print(

--- a/src/rpc.zig
+++ b/src/rpc.zig
@@ -52,6 +52,7 @@ pub const ResponseError = error{
     SystemResources,
     Unexpected,
     UninitializedClient,
+    StreamTooLong,
 };
 pub fn errorResponse(id: ?u32, err: ResponseError) EmptyResponse {
     switch (err) {
@@ -89,6 +90,7 @@ pub fn errorResponse(id: ?u32, err: ResponseError) EmptyResponse {
 
         // Application errors
         error.UninitializedClient => return EmptyResponse.initError(id, 2001, "Client is not initialized"),
+        error.StreamTooLong => return EmptyResponse.initError(id, 2002, "Too long message which is more than `max_packet_size`"),
     }
     unreachable;
 }


### PR DESCRIPTION
We still need some place to store the buffered reader cache
in order to account for several messages being read at a
single time.

EDIT: solved